### PR TITLE
Ios 847

### DIFF
--- a/FunctionalKit.xcodeproj/project.pbxproj
+++ b/FunctionalKit.xcodeproj/project.pbxproj
@@ -630,7 +630,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo \"Checking for Sourcery...\"\nif [ -x \"$(command -v sourcery)\" ]; then\n    echo \"Sourcery found.\"\n    echo \"Generating source files...\"\n    sourcery --sources \"Sources\" --templates \"Templates/Sources\" --output \"Sources/FunctionalKit\"\n    echo \"Generating test files...\"\n    sourcery --sources \"Sources\" --templates \"Templates/Tests\" --output \"Tests/FunctionalKitTests\"\nelse\n    echo \"Sourcery is not installed, ignoring.\"\nfi";
+			shellScript = "echo \"Checking for Sourcery...\"\nif [ -x \"$(command -v sourcery)\" ]; then\n    echo \"Sourcery found.\"\n    echo \"Generating source files...\"\n    sourcery --sources \"Sources\" --templates \"Templates/Sources\" --output \"Sources/FunctionalKit\"\n    echo \"Generating test files...\"\n    sourcery --sources \"Sources\" --templates \"Templates/Tests\" --output \"Tests/FunctionalKitTests\"\nelse\n    echo \"Sourcery is not installed, ignoring.\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Sources/FunctionalKit/Combinators.swift
+++ b/Sources/FunctionalKit/Combinators.swift
@@ -122,5 +122,5 @@ public func <| <A,B> (function: (A) throws -> B, value: A) rethrows -> B {
 }
 
 public func <*> <A,B> (function: (A) throws -> B, value: A) rethrows -> B {
-	return try function(value)
+    return try function(value)
 }

--- a/Sources/FunctionalKit/Coreader.swift
+++ b/Sources/FunctionalKit/Coreader.swift
@@ -5,7 +5,7 @@ public struct Coreader<Environment, Parameter> {
     let environment: Environment
     private let value: Parameter
     
-    init(environment: Environment, value: Parameter) {
+    public init(environment: Environment, value: Parameter) {
         self.environment = environment
         self.value = value
     }

--- a/Sources/FunctionalKit/InclusiveType.swift
+++ b/Sources/FunctionalKit/InclusiveType.swift
@@ -27,7 +27,7 @@ public enum InclusiveError<LeftError,RightError>: Error where LeftError: Error, 
     case center(LeftError, RightError)
     case right(RightError)
     
-    func toInclusive() -> Inclusive<LeftError,RightError> {
+    public func toInclusive() -> Inclusive<LeftError,RightError> {
         switch self {
         case let .left(value):
             return .left(value)
@@ -39,7 +39,27 @@ public enum InclusiveError<LeftError,RightError>: Error where LeftError: Error, 
     }
 }
 
-extension Inclusive where A: Error, B: Error {
+extension InclusiveError: InclusiveType {
+    public typealias LeftType = LeftError
+    public typealias RightType = RightError
+    
+    public func fold<T>(onLeft: @escaping (LeftError) -> T, onCenter: @escaping (LeftError, RightError) -> T, onRight: @escaping (RightError) -> T) -> T {
+        switch self {
+        case let .left(value):
+            return onLeft(value)
+        case let .center(leftValue, rightValue):
+            return onCenter(leftValue, rightValue)
+        case let .right(value):
+            return onRight(value)
+        }
+    }
+    
+    public static func from(inclusive: Inclusive<LeftError, RightError>) -> InclusiveError<LeftError, RightError> {
+        return inclusive.toError()
+    }
+}
+
+public extension Inclusive where A: Error, B: Error {
     func toError() -> InclusiveError<A,B> {
         switch self {
         case let .left(value):

--- a/Sources/FunctionalKit/InclusiveType.swift
+++ b/Sources/FunctionalKit/InclusiveType.swift
@@ -22,7 +22,35 @@ extension Inclusive: InclusiveType {
 	}
 }
 
-extension Inclusive: Error where A: Error, B: Error {}
+public enum InclusiveError<LeftError,RightError>: Error where LeftError: Error, RightError: Error {
+    case left(LeftError)
+    case center(LeftError, RightError)
+    case right(RightError)
+    
+    func toInclusive() -> Inclusive<LeftError,RightError> {
+        switch self {
+        case let .left(value):
+            return .left(value)
+        case let .right(value):
+            return .right(value)
+        case let .center(leftValue,rightValue):
+            return .center(leftValue,rightValue)
+        }
+    }
+}
+
+extension Inclusive where A: Error, B: Error {
+    func toError() -> InclusiveError<A,B> {
+        switch self {
+        case let .left(value):
+            return .left(value)
+        case let .right(value):
+            return .right(value)
+        case let .center(leftValue,rightValue):
+            return .center(leftValue,rightValue)
+        }
+    }
+}
 
 // MARK: - Equatable
 

--- a/Sources/FunctionalKit/Result.swift
+++ b/Sources/FunctionalKit/Result.swift
@@ -94,7 +94,7 @@ public extension Result {
         return { $0.map(function) }
     }
     
-    static func zip <F1,A,F2,B> (_ first: Result<F1,A>, _ second: Result<F2,B>) -> Result<InclusiveError<F1,F2>,(A,B)> where F1: Error, F2: Error, Failure == InclusiveError<F1,F2>, ParameterType == (A,B) {
+    static func zip <F1,A,F2,B> (_ first: Result<F1,A>, _ second: Result<F2,B>) -> Result<InclusiveError<F1,F2>,(A,B)> where Failure == InclusiveError<F1,F2>, ParameterType == (A,B) {
         switch (first, second) {
         case let (.success(leftValue), .success(rightValue)):
             return .success((leftValue,rightValue))

--- a/Sources/FunctionalKit/Result.swift
+++ b/Sources/FunctionalKit/Result.swift
@@ -94,7 +94,7 @@ public extension Result {
         return { $0.map(function) }
     }
     
-    static func zip <F1,A,F2,B> (_ first: Result<F1,A>, _ second: Result<F2,B>) -> Result<Inclusive<F1,F2>,(A,B)> where Failure == Inclusive<F1,F2>, ParameterType == (A,B) {
+    static func zip <F1,A,F2,B> (_ first: Result<F1,A>, _ second: Result<F2,B>) -> Result<InclusiveError<F1,F2>,(A,B)> where F1: Error, F2: Error, Failure == InclusiveError<F1,F2>, ParameterType == (A,B) {
         switch (first, second) {
         case let (.success(leftValue), .success(rightValue)):
             return .success((leftValue,rightValue))
@@ -111,41 +111,13 @@ public extension Result {
     }
     
     static func zipMerged <A,B> (_ first: Result<Failure,A>, _ second: Result<Failure,B>) -> Result<Failure,(A,B)> where Failure: Semigroup {
-        switch (first, second) {
-        case let (.success(leftValue), .success(rightValue)):
-            return .success((leftValue,rightValue))
-            
-        case let (.failure(leftError), .failure(rightError)):
-            return .failure(leftError <> rightError)
-            
-        case let (.failure(error), _):
-            return .failure(error)
-            
-        case let (_, .failure(error)):
-            return .failure(error)
-        }
-        
-        //        return Generic.zip(first, second).mapError { $0.merged() }
+        return Generic.zip(first, second).mapError { $0.toInclusive().merged() }
     }
     
     func apply <A> (_ transform: Result<Failure,(ParameterType) -> A>) -> Result<Failure,A> {
-        switch (self, transform) {
-        case let (.success(leftValue), .success(rightValue)):
-            return .success(rightValue(leftValue))
-            
-        case let (.failure(leftError), .failure):
-            return .failure(leftError)
-            
-        case let (.failure(error), _):
-            return .failure(error)
-            
-        case let (_, .failure(error)):
-            return .failure(error)
-        }
-        
-        //        return Generic.zip(self, transform)
-        //            .map { value, function in function(value) }
-        //            .mapError { $0.left }
+        return Generic.zip(self, transform)
+            .map { value, function in function(value) }
+            .mapError { $0.toInclusive().left }
     }
     
     func applyMerged <A> (_ transform: Result<Failure,(ParameterType) -> A>) -> Result<Failure,A> where Failure: Semigroup {
@@ -154,19 +126,9 @@ public extension Result {
     }
     
     func call <A,B> (_ value: Result<Failure,A>) -> Result<Failure,B> where ParameterType == (A) -> B {
-        switch (value, self) {
-        case let (.success(leftValue),.success(rightValue)):
-            return .success(rightValue(leftValue))
-        case let (.failure(leftError), .failure):
-            return .failure(leftError)
-        case let (.failure(error), _):
-            return .failure(error)
-        case let (_, .failure(error)):
-            return .failure(error)
-        }
-        //        return Generic.zip(self, value)
-        //            .map { function, value in function(value) }
-        //            .mapError { $0.left }
+        return Generic.zip(self, value)
+            .map { function, value in function(value) }
+            .mapError { $0.toInclusive().left }
     }
     
     func callMerged <A,B> (_ value: Result<Failure,A>) -> Result<Failure,B> where ParameterType == (A) -> B, Failure: Semigroup {

--- a/Tests/FunctionalKitTests/LawsTests.generated.swift
+++ b/Tests/FunctionalKitTests/LawsTests.generated.swift
@@ -386,6 +386,11 @@ class LawsTests: XCTestCase {
 
 
 
+
+
+
+
+
 //MARK: - Optional - Functor
 
     func testOptionalFunctorIdentity() {


### PR DESCRIPTION
Starting from Swift 5, `Result.zip` started to produce a Segmentation fault: 11.
In the last release of FunctionalKit we found a workaround to make everything compile, but it wasn't enough and we add many problem on our projects that used `Result.zip`.
After a deeper analysis, we discovered that the problem (probably) is caused by the signature of `zip`. It says that it's return type is `Result<Inclusive<F1,F2>,(A,B)>`. `Failure` generic type of `Result` must implement `Error` protocol. `Inclusive` has this extension, that will make this possible:
`extension Inclusive: Error where LeftType: Error, RightType: Error`
It seems like  that Swift 5 compiler is not able anymore to get this info and, so, it fails.

To solve this problem, we introduce a new `InclusiveError` type.