### PR TITLE
IOS-1688: Remove reference to unused Playground.playground file

### DIFF
--- a/Playground.playground/playground.xcworkspace/contents.xcworkspacedata
+++ b/Playground.playground/playground.xcworkspace/contents.xcworkspacedata
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-</Workspace>


### PR DESCRIPTION
`Playground.playground` file was present but not used or referenced anywhere. This is the reason why we had this error in the projects that imported FunctionalKit

<img width="246" alt="Screenshot 2022-01-31 at 11 40 38" src="https://user-images.githubusercontent.com/9074925/151977323-c8c4be7a-0cd2-4401-b9ca-b3929a649bb2.png">